### PR TITLE
Declare delay1 globally

### DIFF
--- a/include/audio_pipeline.h
+++ b/include/audio_pipeline.h
@@ -3,6 +3,8 @@
 
 #include <Audio.h>
 
+extern AudioEffectDelay delay1;
+
 void setupAudioPipeline();
 void processAudioQueues();
 float processDirt(float sample);

--- a/rough/rough.ino
+++ b/rough/rough.ino
@@ -30,7 +30,7 @@ float mixAmount = 0.5; // Wet/dry mix
 
 // === Audio Objects ===
 AudioInputI2S          i2sIn;            // Input from Teensy Audio Shield
-AudioEffectDelay       delay1;
+extern AudioEffectDelay delay1;
 AudioFilterStateVariable filter1;
 AudioPlayQueue         queueL, queueR;
 AudioPlayQueue         cleanQueueL, cleanQueueR;


### PR DESCRIPTION
## Summary
- expose `delay1` as an extern in the audio pipeline header
- reference the shared `delay1` instance from `rough.ino`

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686094258b1083258baa714e4a069ecc