### PR TITLE
Expose audio objects globally

### DIFF
--- a/include/audio_pipeline.h
+++ b/include/audio_pipeline.h
@@ -3,7 +3,15 @@
 
 #include <Audio.h>
 
+extern AudioInputI2S i2sIn;
 extern AudioEffectDelay delay1;
+extern AudioFilterStateVariable filter1;
+extern AudioPlayQueue queueL, queueR;
+extern AudioPlayQueue cleanQueueL, cleanQueueR;
+extern AudioEffectEnvelope limiter1;
+extern AudioOutputI2S i2sOut;
+
+extern float mixAmount;
 
 void setupAudioPipeline();
 void processAudioQueues();

--- a/include/controls.h
+++ b/include/controls.h
@@ -4,7 +4,6 @@
 void setupControls();
 void updateControl();
 
-extern float mixAmount;
 extern int noiseAmount;
 extern int density;
 

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -17,7 +17,6 @@ const int maxChaosLevel = 8;
 bool reseedButtonState = false;
 bool resetButtonState = false;
 
-float mixAmount = 0.5;
 int noiseAmount = 20;
 int density = 5;
 


### PR DESCRIPTION
## Summary
- provide extern declarations for all audio objects
- expose `mixAmount` globally
- remove duplicate `mixAmount` definition from controls
- clean up controls header

## Testing
- `pio run` *(fails: `pio` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f4c61b908325afb551e2f31006e7