### PR TITLE
Define mixAmount variable

### DIFF
--- a/src/audio_pipeline.cpp
+++ b/src/audio_pipeline.cpp
@@ -26,6 +26,8 @@ AudioConnection patchCord6(delay1, 1, queueR, 0);
 AudioConnection patchCord7(limiter1, 0, i2sOut, 0);
 AudioConnection patchCord8(limiter1, 1, i2sOut, 1);
 
+float mixAmount = 0.5f;
+
 float processDirt(float sample) {
   // Bit-crush the incoming sample to introduce dirt/noise
   const int crushBits = 4;


### PR DESCRIPTION
## Summary
- add missing `mixAmount` global definition

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640c3ccc5c8325a17051f236fa43fd