### PR TITLE
Fix updateLEDBar signature mismatch

### DIFF
--- a/include/ui.h
+++ b/include/ui.h
@@ -3,6 +3,6 @@
 #define UI
 
 void setupUI();
-void updateLEDBar();
+void updateLEDBar(int level);
 
 #endif

--- a/rough/rough.ino
+++ b/rough/rough.ino
@@ -90,8 +90,8 @@ void processAudioQueues() {
   }
 }
 
-void updateLEDBar() {
-  byte ledPattern = 0b11111111 >> (8 - buttonPressCount);
+void updateLEDBar(int level) {
+  byte ledPattern = 0b11111111 >> (8 - level);
   digitalWrite(ledLatchPin, LOW);
   shiftOut(ledDataPin, ledClockPin, MSBFIRST, ledPattern);
   digitalWrite(ledLatchPin, HIGH);
@@ -118,7 +118,7 @@ void setup() {
   limiter1.hold(50);
 
   randomSeed(analogRead(randomSourcePin));
-  updateLEDBar();
+  updateLEDBar(buttonPressCount);
 }
 
 void updateControl() {
@@ -133,7 +133,7 @@ void updateControl() {
       noiseAmount = constrain(noiseAmount, 20, 60);
       density = constrain(density, 5, 100);
       randomSeed(analogRead(randomSourcePin));
-      updateLEDBar();
+      updateLEDBar(buttonPressCount);
     }
   } else {
     reseedButtonState = false;
@@ -147,7 +147,7 @@ void updateControl() {
       noiseAmount = 20;
       density = 5;
       randomSeed(analogRead(randomSourcePin));
-      updateLEDBar();
+      updateLEDBar(buttonPressCount);
     }
   } else {
     resetButtonState = false;


### PR DESCRIPTION
## Summary
- update header for `updateLEDBar` to take a level parameter
- adjust prototype calls in example `rough.ino`

## Testing
- `platformio run` *(fails: command not found)*
- `g++ -std=c++17 -Iinclude -c src/ui.cpp -o /tmp/ui.o` *(fails: Arduino.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68640c3e7c1c832586f38b2d76b3f086