### PR TITLE
Implement density and noise controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ## Overview
 teensyDee2 implements a chaotic delay effect for the **Teensy 4.0** microcontroller with the
-official Audio Shield. It mixes a clean signal with a noisy, density-modulated delay
-line to produce unstable, glitchy echoes. Two push buttons let you reseed or reset
+official Audio Shield. It mixes a clean signal with a noisy, density‑modulated delay
+line to produce unstable, glitchy echoes. The amount of bit‑crushing and how often
+glitches occur are shaped by the *noise amount* and *density* controls. Two push buttons let you reseed or reset
 the random parameters while five pots control the effect in real time.
 
 ## Hardware Requirements
@@ -25,8 +26,10 @@ and [`src/ui.cpp`](src/ui.cpp).
 The firmware exposes several parameters, as defined in `controls.cpp`:
 - **Delay time** &ndash; sets the delay length in milliseconds.
 - **Feedback** &ndash; adjusts how much of the delayed signal is fed back.
-- **Noise amount** &ndash; controls bit‑crushing/noise applied to the feedback path.
-- **Density** &ndash; governs how often noisy glitches are added.
+- **Noise amount** &ndash; sets the intensity of the bit‑crush and noise added
+  to the delay line.
+- **Density** &ndash; controls the probability that a sample will be glitched,
+  effectively adjusting how frequently dirt is injected.
 - **Mix** &ndash; blends between the clean and dirty signals.
 - **Reseed / Reset buttons** &ndash; randomise or clear the chaos values.
 

--- a/src/audio_pipeline.cpp
+++ b/src/audio_pipeline.cpp
@@ -27,13 +27,26 @@ AudioConnection patchCord7(limiter1, 0, i2sOut, 0);
 AudioConnection patchCord8(limiter1, 1, i2sOut, 1);
 
 float processDirt(float sample) {
-  // Bit-crush the incoming sample to introduce dirt/noise
-  const int crushBits = 4;
-  int crushed = int(sample * (1 << crushBits));
-  float crushedSample = float(crushed) / (1 << crushBits);
-  if (crushedSample > 0.8) crushedSample = 0.8;
-  if (crushedSample < -0.8) crushedSample = -0.8;
-  return crushedSample;
+  // Apply glitch only on a percentage of samples defined by `density`.
+  if (random(100) >= density) {
+    return sample;
+  }
+
+  // Map noiseAmount (0-60) to a reduction in bit depth. Higher values
+  // mean fewer bits and therefore harsher crushing.
+  int crushBits = 8 - noiseAmount / 10; // range roughly 8..2
+  if (crushBits < 2) crushBits = 2;
+  int steps = 1 << crushBits;
+
+  int crushed = int(sample * steps);
+  float crushedSample = float(crushed) / steps;
+
+  // Inject random noise scaled by noiseAmount to add fuzziness
+  float noise = ((float)random(-32768, 32767) / 32767.0f) * (noiseAmount / 100.0f);
+  float result = crushedSample + noise;
+
+  result = constrain(result, -1.0f, 1.0f);
+  return result;
 }
 
 void processAudioQueues() {


### PR DESCRIPTION
## Summary
- add glitch logic using noise amount & density in `processDirt`
- document the behaviour of the new parameters in the README

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640c3f6c408325b193a1b1a18d17a6