### PR TITLE
Amplify documentation and annotate chaos pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ This project straps a chaotic delay line onto a **Teensy 4.0** board and dares y
 feed it audio. Clean tones go in, fractured echoes come out. Every knob twist
 and button jab nudges the randomness, so you're never standing in the same river
 twice. Use it to learn how real-time DSP works, or just to make your synth sound
-like it fell down the stairs.
+like it fell down the stairs. Think of the repo as a lab notebook where every
+subsystem is annotated, diagrammed, and cross-linked so you can both perform and
+reverse-engineer the trickery.
+
+> **Teaching vibe:** The comments and READMEs aim to be rigorous enough for a
+> grad seminar yet still punk enough to keep you awake. Follow the links, read
+> the notes, and then mod the hell out of it.
 
 ## Gear Checklist
 - **Teensy 4.0** with the PJRC Audio Shield with input and outputs wired
@@ -24,19 +30,70 @@ like it fell down the stairs.
 Pin assignments live in `src/controls.cpp` and `src/ui.cpp` so you can swap
 hardware without spelunking the whole codebase.
 
-## Sonic Mayhem Controls
-These parameters are polled each loop and shoved straight into the audio path:
-- **Delay time** – milliseconds of echo stored in `AudioEffectDelay`
-- **Feedback** – gain fed from the delay output back to its input
-- **Noise amount** – number of bits lopped off when crunching the feedback
-- **Density** – percentage chance a sample gets mangled
-- **Mix** – blend between the untouched and the trashed signals
-- **Reseed** – bump up the chaos level and reseed the RNG
-- **Reset** – clear the chaos and start clean
+## Signal Flow Snapshot
+
+```
+┌────────────┐   Audio Shield I2S   ┌─────────────────────┐   ┌─────────────┐
+│ Line / Mic │ ───────────────────► │  filter1 (HPF-ish)  │ ─►│ cleanQueue* │
+└────────────┘                      └─────────┬───────────┘   └─────────────┘
+                                              │
+                                              ▼
+                                    ┌────────────────────┐
+                                    │ delay1 (two taps)  │
+                                    └───────┬───────┬────┘
+                                            │       │
+                                            ▼       ▼
+                                     queueL/queueR  ──► limiter1 ──► I2S out
+                                            │
+                                            ▼
+                                      feedbackMixer ◄─────◄─ filter1
+```
+
+The `processAudioQueues()` function drains the `queue*` buffers, applies the
+bit-crushing chaos via `processDirt()`, blends the dry/wet signals, and pipes
+everything into `limiter1` before the final DAC hop. The ASCII diagram is rough,
+but the code comments mirror it line-by-line so you can always map theory to
+firmware.
+
+## Control Map & Chaos Knob Lore
+
+These parameters are polled each loop and shoved straight into the audio path.
+The comments in `src/controls.cpp` walk through every scaling decision and why
+the chosen ranges work on Teensy 4.0 (3.3 V reference, 10-bit ADC, etc.).
+
+| Physical control | Teensy pin | Firmware symbol | Range & behaviour |
+| ---------------- | ---------- | --------------- | ----------------- |
+| Delay pot        | `A0`       | `delay1.delay`  | 1 ms – 300 ms of buffer on tap 0 |
+| Feedback pot     | `A1`       | `feedbackAmount`| 0.00 – 1.00 linear gain into feedback mixer |
+| Noise pot        | `A3`       | `noiseAmount`   | 0 – 60 → maps to 2–8 bit resolution in crusher |
+| Density pot      | `A4`       | `density`       | 0 – 100% chance that a sample is crushed |
+| Mix pot          | `A5`       | `mixAmount`     | 0.00 – 1.00 dry/wet crossfade |
+| Reseed button    | `8`        | chaos ladder    | Adds +5 bits of nastiness per press until clamped |
+| Reset button     | `7`        | chaos ladder    | Slams everything back to polite defaults |
+
+The chaos ladder is intentionally dramatic: each reseed press ratchets both the
+bit crushing depth and the glitch density, while also reseeding the RNG from an
+analog pin so the statistical flavour changes in a way you can actually hear.
 
 `src/audio_pipeline.cpp` handles the mixing and bit‑crushing while
 `src/controls.cpp` maps the knobs and buttons to those globals. It's all plain
 C++ and Arduino APIs—poke around and hack it.
+
+### Teaching Notes
+
+- **Signal levels:** The Teensy audio library pushes 16-bit signed integers in
+  the range ±32767 inside `audio_block_t`. The comments in `processAudioQueues`
+  spell out the conversion math so you can swap in your own fixed-point tricks.
+- **Why the filter first?** `filter1` is configured as a gentle high-pass to
+  keep DC out of the delay feedback path. A low, sticky offset will otherwise
+  cause the delay to saturate. Change the frequency/resonance in
+  `setupAudioPipeline()` and hear the difference.
+- **Probability-based glitching:** `density` is interpreted as a % chance that
+  we crush the current sample. This keeps the behaviour simple and makes it
+  easy to swap in other distributions (Gaussian, correlated noise, etc.).
+- **Feedback safety:** The limiter and explicit `constrain()` calls keep the
+  feedback loop from rage quitting. Kill them if you want self-oscillation, but
+  do it intentionally.
 
 ## Build & Flash
 Built with [PlatformIO](https://platformio.org/). From the repo root:
@@ -49,11 +106,27 @@ pio run -t upload  # flash it to the board
 `platform.ini` already targets the Teensy 4.0, so the above is enough to get
 code onto the hardware.
 
+> **Heads up:** The first `pio run` after cloning will pull in the entire
+> [PJRC Audio library](https://www.pjrc.com/teensy/td_libs_Audio.html). Expect a
+> minute or two. Future builds are quick.
+
 ## Repo Tour
 - `src/` – firmware sources: `main.cpp`, `audio_pipeline.cpp`, `controls.cpp`,
   `ui.cpp`, `chaos.cpp`
 - `include/` – headers shared across those files
 - `rough/` – early Arduino sketch kept for historical kicks
+
+## Study Pointers & Further Reading
+
+- [Teensy Audio System Design Tool](https://www.pjrc.com/teensy/gui/index.html)
+  – Drag blocks, wire them up, and export Arduino code. Compare the generated
+  code to our hand-crafted setup in `src/audio_pipeline.cpp`.
+- [PlatformIO Teensy Docs](https://docs.platformio.org/en/latest/boards/teensy/teensy40.html)
+  – Explains the board configuration you inherit via `platform.ini`.
+- [Bit crushing primer](https://ccrma.stanford.edu/~jos/filters/Bit_Reduction_Distortion.html)
+  – Stanford CCRMA notes on what actually happens when you nuke bit depth.
+- [Finite state machine for buttons](https://www.ganssle.com/debouncing.htm)
+  – Want to replace the naive `delay(50)` debounce? Start here.
 
 ## Contributing / License
 No explicit license. Consider it public domain punk: use, abuse, and send PRs if

--- a/include/audio_pipeline.h
+++ b/include/audio_pipeline.h
@@ -1,24 +1,29 @@
-// Definitions for the audio processing pipeline. Provides setup
-// and buffer mixing utilities used by the main firmware.
+// Audio processing pipeline public API.
+//
+// Exposes the globally-instantiated Audio objects as well as helper functions
+// for initialisation and queue processing. This mirrors the structure laid out
+// in src/audio_pipeline.cpp and lets other modules (controls, main) poke values
+// directly without additional plumbing.
 #ifndef AUDIO_PIPELINE_H
 #define AUDIO_PIPELINE_H
 
 #include <Audio.h>
 
-extern AudioInputI2S i2sIn;
-extern AudioEffectDelay delay1;
-extern AudioFilterStateVariable filter1;
-extern AudioPlayQueue queueL, queueR;
-extern AudioPlayQueue cleanQueueL, cleanQueueR;
-extern AudioEffectEnvelope limiter1;
-extern AudioOutputI2S i2sOut;
-extern AudioMixer4 feedbackMixer;
+extern AudioInputI2S i2sIn;                // Audio shield line in
+extern AudioEffectDelay delay1;            // Dual-tap delay line
+extern AudioFilterStateVariable filter1;   // High-pass conditioning filter
+extern AudioPlayQueue queueL, queueR;      // Post-delay dirty taps
+extern AudioPlayQueue cleanQueueL, cleanQueueR; // Pre-delay clean taps
+extern AudioEffectEnvelope limiter1;       // Dynamics safety net
+extern AudioOutputI2S i2sOut;              // Audio shield line out
+extern AudioMixer4 feedbackMixer;          // Combines dry signal + feedback loop
 
-extern float mixAmount;
-extern float feedbackAmount;
+extern float mixAmount;                    // Dry/wet crossfade coefficient
+extern float feedbackAmount;               // Feedback loop gain coefficient
 
 void setupAudioPipeline();
 void processAudioQueues();
 float processDirt(float sample);
 
 #endif
+

--- a/include/chaos.h
+++ b/include/chaos.h
@@ -1,7 +1,11 @@
-// Forward declarations for chaos related functionality.
+// Chaos subsystem public API placeholder.
+//
+// Keeping this header separate lets future modulators stay decoupled from the
+// audio/control headers until they actually need to exchange data.
 #ifndef CHAOS_H
 #define CHAOS_H
 
-void setupChaos();
+void setupChaos(); // call once from setup() to initialise chaos utilities
 
 #endif
+

--- a/include/controls.h
+++ b/include/controls.h
@@ -1,12 +1,15 @@
-// Interface for reading hardware controls and exposing
-// the resulting global parameters used by the audio engine.
+// Control surface public API.
+//
+// The implementation keeps live state in globals so the audio pipeline can grab
+// the latest values each audio block without function call overhead.
 #ifndef CONTROLS_H
 #define CONTROLS_H
 
 void setupControls();
 void updateControl();
 
-extern int noiseAmount;
-extern int density;
+extern int noiseAmount; // 0–60 bit-crusher intensity scalar
+extern int density;     // 0–100 probability (%) that a sample gets crushed
 
 #endif
+

--- a/include/ui.h
+++ b/include/ui.h
@@ -1,8 +1,12 @@
-// Simple LED bar UI helpers
+// LED bar UI helpers.
+//
+// Wrapped in their own header so other modules can update the display without
+// dragging in Arduino UI specifics.
 #ifndef UI
 #define UI
 
-void setupUI();
-void updateLEDBar(int level);
+void setupUI();               // configure shift-register pins
+void updateLEDBar(int level); // display current chaos level (0–8 LEDs)
 
 #endif
+

--- a/src/audio_pipeline.cpp
+++ b/src/audio_pipeline.cpp
@@ -1,8 +1,27 @@
-// Audio processing pipeline. Handles delay line, filtering and mixing
-// between the clean and "dirty" signals. Key functions:
-//   - setupAudioPipeline() : initialises the audio objects
-//   - processAudioQueues() : mixes clean and dirty buffers
-//   - processDirt()        : applies bit crushing
+// Audio processing pipeline for the chaos delay.
+//
+// The Teensy Audio Library builds a directed graph of `AudioStream` objects.
+// The graph below mirrors the signal flow ASCII art in README.md. Each global
+// object represents a node; the `AudioConnection` instances form the edges.
+//
+// ┌───────────────┐    ┌──────────────┐    ┌─────────────┐
+// │ AudioInputI2S │───►│ filter1 (SVF)│───►│ feedbackMixer│──┐
+// └───────────────┘    └──────┬───────┘    └────┬────────┘  │
+//                              │                 │           │
+//                              ▼                 │           │
+//                     cleanQueueL/R (tap)        │           │
+//                              │                 │           │
+//                              ▼                 │           │
+//                       delay1 (stereo taps)     │◄──────────┘
+//                              │
+//                              ▼
+//                        queueL/queueR
+//                              │
+//                              ▼
+//                         limiter1 → i2sOut
+//
+// The helper functions in this file set up the graph and then manually mix the
+// queue buffers so we can sprinkle in probabilistic bit crushing.
 #include "audio_pipeline.h"
 #include "Arduino.h"
 #include "controls.h"
@@ -17,6 +36,8 @@ AudioEffectEnvelope    limiter1;
 AudioOutputI2S         i2sOut;
 AudioMixer4           feedbackMixer;
 
+// `feedbackAmount` mirrors the front-panel feedback pot and is shared with the
+// controls module. It is applied as gain on `feedbackMixer` input 1.
 float feedbackAmount = 0.0f;
 
 // === Audio Connections ===
@@ -31,24 +52,29 @@ AudioConnection patchCord8(delay1, 1, queueR, 0);
 AudioConnection patchCord9(limiter1, 0, i2sOut, 0);
 AudioConnection patchCord10(limiter1, 1, i2sOut, 1);
 
+// Ratio of dirty (post-delay) to clean (pre-delay) signal. 0 = dry, 1 = fully
+// crushed chaos.
 float mixAmount = 0.5f;
 
 float processDirt(float sample) {
   // Apply glitch only on a percentage of samples defined by `density`.
+  // `density` comes from the controls module and represents 0–100%.
   if (random(100) >= density) {
     return sample;
   }
 
-  // Map noiseAmount (0-60) to a reduction in bit depth. Higher values
-  // mean fewer bits and therefore harsher crushing.
-  int crushBits = 8 - noiseAmount / 10; // range roughly 8..2
+  // Map noiseAmount (0-60) to a reduction in bit depth. Higher values mean
+  // fewer bits and therefore harsher crushing. The formula intentionally keeps
+  // the lowest resolution at 2 bits so the waveform retains *some* structure.
+  int crushBits = 8 - noiseAmount / 10; // roughly 8..2 bits of resolution
   if (crushBits < 2) crushBits = 2;
   int steps = 1 << crushBits;
 
   int crushed = int(sample * steps);
   float crushedSample = float(crushed) / steps;
 
-  // Inject random noise scaled by noiseAmount to add fuzziness
+  // Inject random noise scaled by noiseAmount to add fuzziness. Random returns
+  // a 15-bit integer; we normalise to ±1.0 and scale by a 0–0.6 factor.
   float noise = ((float)random(-32768, 32767) / 32767.0f) * (noiseAmount / 100.0f);
   float result = crushedSample + noise;
 
@@ -58,13 +84,15 @@ float processDirt(float sample) {
 
 void processAudioQueues() {
   if (queueL.available() && cleanQueueL.available()) {
-    // Mix left channel from clean and dirty delay buffers
+    // Mix left channel from clean and dirty delay buffers. Audio blocks are
+    // 128-sample chunks. Teensy represents them as int16_t where ±32767 equals
+    // ±1.0f. We convert to floats for clarity then convert back.
     audio_block_t *dirty = queueL.readBuffer();
     audio_block_t *clean = cleanQueueL.readBuffer();
     for (int i = 0; i < AUDIO_BLOCK_SAMPLES; i++) {
       float c = (float)clean->data[i] / 32768.0f;
       float d = (float)dirty->data[i] / 32768.0f;
-      // Apply dirt and blend with clean signal
+      // Apply dirt and blend with clean signal.
       d = processDirt(d);
       float mixed = (1.0f - mixAmount) * c + mixAmount * d;
       mixed = constrain(mixed, -1.0f, 1.0f);
@@ -75,13 +103,13 @@ void processAudioQueues() {
   }
 
   if (queueR.available() && cleanQueueR.available()) {
-    // Mix right channel from clean and dirty delay buffers
+    // Repeat the same dance for the right channel.
     audio_block_t *dirty = queueR.readBuffer();
     audio_block_t *clean = cleanQueueR.readBuffer();
     for (int i = 0; i < AUDIO_BLOCK_SAMPLES; i++) {
       float c = (float)clean->data[i] / 32768.0f;
       float d = (float)dirty->data[i] / 32768.0f;
-      // Apply dirt and blend with clean signal
+      // Apply dirt and blend with clean signal.
       d = processDirt(d);
       float mixed = (1.0f - mixAmount) * c + mixAmount * d;
       mixed = constrain(mixed, -1.0f, 1.0f);
@@ -93,10 +121,13 @@ void processAudioQueues() {
 }
 
 void setupAudioPipeline() {
-  // Reserve audio memory buffers
+  // Reserve audio memory buffers. Each block equals 128 samples, so 60 blocks
+  // gives the delay ample breathing room without starving the mixer.
   AudioMemory(60);
 
-  // Configure delay and filter defaults
+  // Configure delay and filter defaults. `delay1.delay(0, x)` sets tap 0 (left)
+  // to x milliseconds. The right channel uses the library default and is
+  // modulated via the same API if desired.
   delay1.delay(0, 200);
   filter1.frequency(500);
   filter1.resonance(0.7);
@@ -104,8 +135,10 @@ void setupAudioPipeline() {
   feedbackMixer.gain(0, 1.0f);
   feedbackMixer.gain(1, feedbackAmount);
 
-  // Basic limiter settings to keep level in check
+  // Basic limiter settings to keep level in check. Adjust attack/release to
+  // taste; the defaults keep transients snappy while catching runaway feedback.
   limiter1.attack(5);
   limiter1.release(100);
   limiter1.hold(50);
 }
+

--- a/src/chaos.cpp
+++ b/src/chaos.cpp
@@ -1,9 +1,16 @@
-// Chaos utilities. Currently minimal but reserved for future
-// modulation sources. Only exposes setupChaos for initialisation.
+// Chaos utilities namespace.
+//
+// Right now the "chaos" concept lives mostly inside controls.cpp. This file is
+// a staging area for any modulation sources that need to tick over time (LFOs,
+// Lorenz attractors, etc.). By keeping the scaffold ready we lower the barrier
+// to experiment later without bloating main.cpp.
 #include "chaos.h"
 #include <Arduino.h>
 
 void setupChaos() {
-  // Placeholder for chaos LFO or other modulation
-  // Parameters are currently reseeded via the controls logic
+  // Placeholder for chaos LFO or other modulation sources. At boot we simply
+  // spit a debug banner so you know the subsystem initialised; comment it out on
+  // production builds if noise bothers you.
+  Serial.println("[chaos] subsystem armed - add modulators in chaos.cpp");
 }
+

--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -1,5 +1,13 @@
-// Reads pots and buttons and updates global parameters
-// controlling the delay and chaos behaviour.
+// Hardware control surface glue code.
+//
+// Responsibilities:
+//   • Read the five analog pots, scale them into musically useful ranges, and
+//     push the values into the audio subsystem globals.
+//   • Watch the two momentary buttons and ladder up/down the "chaos" state.
+//   • Keep the LED bar in sync so performers can see how feral things are.
+//
+// Design notes live inline; treat this file as both implementation and lab
+// notebook.
 #include "controls.h"
 #include "audio_pipeline.h"
 #include "ui.h"
@@ -12,28 +20,37 @@ const int potDensityPin = A4;
 const int potMixPin = A5;
 const int reseedButtonPin = 8;
 const int resetButtonPin = 7;
-const int randomSourcePin = 9;
+const int randomSourcePin = 9;  // PWM pin used as an entropy source when read
 
-int buttonPressCount = 0;
-const int maxChaosLevel = 8;
-bool reseedButtonState = false;
-bool resetButtonState = false;
+int buttonPressCount = 0;       // Tracks current chaos ladder position (0..8)
+const int maxChaosLevel = 8;    // Upper bound for chaos ladder
+bool reseedButtonState = false; // Edge-detect latch for reseed button
+bool resetButtonState = false;  // Edge-detect latch for reset button
 
+// Globals exposed in controls.h so the audio pipeline can read them without
+// circular dependencies. Defaults are intentionally modest so the unit powers on
+// in a polite state.
 int noiseAmount = 20;
 int density = 5;
 
 void setupControls() {
-  // Configure buttons and random source pin
+  // Configure buttons and random source pin. INPUT_PULLUP keeps the buttons
+  // stable without external resistors (logic low means "pressed").
   pinMode(reseedButtonPin, INPUT_PULLUP);
   pinMode(resetButtonPin, INPUT_PULLUP);
   pinMode(randomSourcePin, OUTPUT);
   analogWriteFrequency(randomSourcePin, 25000);
 
-  // Seed RNG from an unconnected analog pin
+  // Seed RNG from the PWM pin. Because we never connect anything to it, its
+  // analog readback carries thermal noise that provides a slightly chaotic seed.
   randomSeed(analogRead(randomSourcePin));
 }
 
 void updateControl() {
+  // === Button handling ===
+  // Buttons are debounced with a primitive delay to keep the code legible for
+  // beginners. See README for links if you want to replace it with a real FSM.
+
   // Check reseed button to increase chaos level
   if (digitalRead(reseedButtonPin) == LOW) {
     delay(50);
@@ -67,22 +84,30 @@ void updateControl() {
     resetButtonState = false;
   }
 
-  // Read pots and map them to parameter ranges
+  // === Pot handling ===
+  // The Teensy 4.0 ADC reports 0–1023 for 0–3.3 V. Each map()/division converts
+  // that range into something meaningful for the DSP stage.
+
+  // Delay time: map to 1–300 ms on tap 0.
   int potDelayValue = analogRead(potDelayPin);
   delay1.delay(0, map(potDelayValue, 0, 1023, 1, 300));
 
+  // Feedback: convert to a 0.00–1.00 linear gain, then feed into the mixer.
   int potFeedbackValue = analogRead(potFeedbackPin);
   feedbackAmount = map(potFeedbackValue, 0, 1023, 0, 100) / 100.0;
   feedbackMixer.gain(1, feedbackAmount);
 
+  // Noise + density pots override the ladder when turned. We still keep the
+  // ladder counts so the LED bar reflects the most recent button action.
   noiseAmount = map(analogRead(potNoiseAmountPin), 0, 1023, 0, 60);
   density = map(analogRead(potDensityPin), 0, 1023, 0, 100);
   mixAmount = map(analogRead(potMixPin), 0, 1023, 0, 100) / 100.0;
 
-  // Output debug information over serial
+  // Output debug information over serial so you can watch values without a scope.
   Serial.print("Delay: "); Serial.print(potDelayValue);
   Serial.print(" | Feedback: "); Serial.print(feedbackAmount);
   Serial.print(" | Noise: "); Serial.print(noiseAmount);
   Serial.print(" | Density: "); Serial.print(density);
   Serial.print(" | Mix: "); Serial.println(mixAmount);
 }
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,12 @@
-// Entry point for the Teensy Chaos Delay firmware.
-// Initialises subsystems and services the main loop.
+// teensyDee2 firmware entry point.
+//
+// This file intentionally stays tiny: it documents the overall boot flow and
+// leaves the heavy lifting to the subsystems in `src/`. Treat it as the
+// high-level syllabus for the firmware.
+//
+// Boot order matters on the Teensy audio stack, so we call `setupUI()` first to
+// ensure indicator LEDs don't flicker garbage, wire up controls, allocate audio
+// memory, and only then prime the chaos helpers.
 #include <Arduino.h>
 #include "audio_pipeline.h"
 #include "controls.h"
@@ -8,7 +15,9 @@
 
 void setup() {
   Serial.begin(9600);
-  // Initialise hardware subsystems
+  // Initialise hardware subsystems. Each setup routine documents its own
+  // dependencies and side effects so you can reorder or swap components on your
+  // own builds.
   setupUI();
   setupControls();
   setupAudioPipeline();
@@ -16,7 +25,10 @@ void setup() {
 }
 
 void loop() {
-  // Poll controls and then process audio buffers
+  // Poll controls to refresh globals (pot values, button presses, chaos state)
+  // and then drain audio queues. The order keeps latency low: we always process
+  // control changes before pushing a fresh audio block.
   updateControl();
   processAudioQueues();
 }
+

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1,5 +1,9 @@
-// Simple LED bar UI handled via shift register pins.
-// Provides setupUI() and updateLEDBar().
+// LED bar user interface helper functions.
+//
+// The LED bar is driven through a 74HC595 shift register (or similar). We keep
+// this file focused on explaining the timing: latch low → shift out byte → latch
+// high. Modify `updateLEDBar` if your LED order differs or if you want fancy
+// animations.
 #include "ui.h"
 #include "Arduino.h"
 
@@ -15,9 +19,16 @@ void setupUI() {
 }
 
 void updateLEDBar(int level) {
-  // Display the given level using a simple shifting pattern
-  byte ledPattern = 0b11111111 >> (8 - level);
+  // Display the given level using a simple shifting pattern. `level` is expected
+  // to be 0–8. We guard against out-of-range values to avoid shifting garbage.
+  if (level < 0) level = 0;
+  if (level > 8) level = 8;
+
+  // Using MSBFIRST means bit 7 maps to the LED closest to the data pin. If your
+  // hardware is flipped, adjust the shift direction.
+  byte ledPattern = (level == 0) ? 0 : (0xFF >> (8 - level));
   digitalWrite(ledLatchPin, LOW);
   shiftOut(ledDataPin, ledClockPin, MSBFIRST, ledPattern);
   digitalWrite(ledLatchPin, HIGH);
 }
+


### PR DESCRIPTION
## Summary
- expand the top-level README with a signal-flow snapshot, control map, and study links to turn the repo into a teaching notebook
- annotate the audio, control, UI, and chaos modules with rigorous inline commentary and clearer global variable docs
- add guard rails for the LED bar level handling and a boot log for the chaos subsystem

## Testing
- `pio run` *(fails: PlatformIO is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df26d2be54832595b2565616520b9c